### PR TITLE
Add ANSI_QUOTES to sql_mode to support MySQL 8 compatibility 

### DIFF
--- a/.github/workflows/go-with-mysql-postgres-db.yml
+++ b/.github/workflows/go-with-mysql-postgres-db.yml
@@ -31,6 +31,17 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
+      mysql8:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: mysql
+        ports:
+        - 3306/tcp
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
     - uses: actions/checkout@v2
@@ -63,6 +74,14 @@ jobs:
         DB_PASSWORD: mysql
         DB_HOST: 127.0.0.1
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
+
+    - name: Test Mysql8
+      run: ./scripts/test.sh
+      env:
+        DB: mysql
+        DB_PASSWORD: mysql
+        DB_HOST: 127.0.0.1
+        DB_PORT: ${{ job.services.mysql8.ports[3306] }}
 
   promote:
     needs: test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,16 @@ running against a recent version of Go.
 
 ## Running SQL Tests
 
-### MySQL
+### MySQL 5.7
 
 ```
 DB=mysql ./scripts/docker-test
+```
+
+### MySQL 8
+
+```
+DB=mysql8 ./scripts/docker-test
 ```
 
 ### Postgres

--- a/db/config_test.go
+++ b/db/config_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Config", func() {
 			It("returns the connection string", func() {
 				connectionString, err := config.ConnectionString()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&writeTimeout=5s"))
+				Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&writeTimeout=5s&sql_mode=%28SELECT+CONCAT%28%40%40sql_mode%2C%27%2CANSI_QUOTES%27%29%29"))
 			})
 
 			Context("when require_ssl is enabled", func() {
@@ -161,7 +161,7 @@ var _ = Describe("Config", func() {
 					It("returns the amended connection string", func() {
 						connectionString, err := config.ConnectionString()
 						Expect(err).NotTo(HaveOccurred())
-						Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s"))
+						Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s&sql_mode=%28SELECT+CONCAT%28%40%40sql_mode%2C%27%2CANSI_QUOTES%27%29%29"))
 					})
 				})
 

--- a/db/connection_pool.go
+++ b/db/connection_pool.go
@@ -31,7 +31,7 @@ func NewConnectionPool(conf Config,
 	connectionPool.SetMaxOpenConns(maxOpenConnections)
 	connectionPool.SetMaxIdleConns(maxIdleConnections)
 	connectionPool.SetConnMaxLifetime(connMaxLifetime)
-	logger.Info("db connection retrived", lager.Data{})
+	logger.Info("db connection retrieved", lager.Data{})
 
 	return connectionPool, nil
 }

--- a/db/mysql_connection_string_builder.go
+++ b/db/mysql_connection_string_builder.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
@@ -21,7 +22,8 @@ type MySQLConnectionStringBuilder struct {
 }
 
 func (m *MySQLConnectionStringBuilder) Build(config Config) (string, error) {
-	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true", config.User, config.Password, config.Host, config.Port, config.DatabaseName)
+	sqlMode := url.QueryEscape("(SELECT CONCAT(@@sql_mode,',ANSI_QUOTES'))")
+	connString := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?parseTime=true&sql_mode=%s", config.User, config.Password, config.Host, config.Port, config.DatabaseName, sqlMode)
 
 	dbConfig, err := m.MySQLAdapter.ParseDSN(connString)
 	if err != nil {

--- a/db/mysql_connection_string_builder_test.go
+++ b/db/mysql_connection_string_builder_test.go
@@ -126,7 +126,7 @@ var _ = Describe("MySQLConnectionStringBuilder", func() {
 		It("builds a connection string", func() {
 			connectionString, err := mysqlConnectionStringBuilder.Build(config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&writeTimeout=5s"))
+			Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&writeTimeout=5s&sql_mode=%28SELECT+CONCAT%28%40%40sql_mode%2C%27%2CANSI_QUOTES%27%29%29"))
 		})
 
 		Context("when mysql.ParseDSN can't parse the connection string", func() {
@@ -161,7 +161,7 @@ var _ = Describe("MySQLConnectionStringBuilder", func() {
 			It("builds a tls connection string", func() {
 				connectionString, err := mysqlConnectionStringBuilder.Build(config)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s"))
+				Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s&sql_mode=%28SELECT+CONCAT%28%40%40sql_mode%2C%27%2CANSI_QUOTES%27%29%29"))
 
 				Expect(mySQLAdapter.RegisterTLSConfigCallCount()).To(Equal(1))
 				passedTLSConfigName, passedTLSConfig := mySQLAdapter.RegisterTLSConfigArgsForCall(0)
@@ -178,7 +178,7 @@ var _ = Describe("MySQLConnectionStringBuilder", func() {
 				It("builds tls config skipping hostname", func() {
 					connectionString, err := mysqlConnectionStringBuilder.Build(config)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s"))
+					Expect(connectionString).To(Equal("some-user:some-password@tcp(some-host:1234)/some-database?parseTime=true&readTimeout=5s&timeout=5s&tls=some-database-tls&writeTimeout=5s&sql_mode=%28SELECT+CONCAT%28%40%40sql_mode%2C%27%2CANSI_QUOTES%27%29%29"))
 
 					Expect(mySQLAdapter.RegisterTLSConfigCallCount()).To(Equal(1))
 					passedTLSConfigName, passedTLSConfig := mySQLAdapter.RegisterTLSConfigArgsForCall(0)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,7 +15,7 @@ function bootDB {
   if [ "$db" = "postgres" ]; then
     launchDB="(docker-entrypoint.sh postgres &> /var/log/postgres-boot.log) &"
     testConnection="psql -h localhost -U postgres -c '\conninfo' &>/dev/null"
-  elif [ "$db" = "mysql" ]  || [ "$db" = "mysql-5.6" ]; then
+  elif [[ "$db" == "mysql"* ]]; then
     launchDB="(MYSQL_ROOT_PASSWORD=password /entrypoint.sh mysqld &> /var/log/mysql-boot.log) &"
     testConnection="echo '\s;' | mysql -h 127.0.0.1 -u root --password='password' &>/dev/null"
   else
@@ -49,14 +49,9 @@ else
   extraArgs="${@}"
 fi
 
-if [ ${DB:-"none"} = "mysql" ] || [ ${DB:-"none"} = "mysql-5.6" ]; then
-  if [ ${DB_PORT:-"none"} = "none" ]; then
-    bootDB ${DB}
-  fi
-  ginkgo -r --race -randomizeAllSpecs ${extraArgs} db/timeouts
-elif [ ${DB:-"none"} = "postgres" ]; then
-  if [ ${DB_PORT:-"none"} = "none" ]; then
-    bootDB ${DB}
+if [ "${DB:-"none"}" != "none" ]; then
+  if [ "${DB_PORT:-"none"}" = "none" ]; then
+    bootDB "${DB}"
   fi
   ginkgo -r --race -randomizeAllSpecs ${extraArgs} db/timeouts
 else


### PR DESCRIPTION
- Setting ANSI_QUOTES mode allows us to use the same syntax for quoting identifiers for both MySQL and PostgreSQL:
  https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes
- With this mode set you can no longer use double quotes to quote literal strings as they are interpreted as identifiers
- Append the ANSI_QUOTES SQL mode to the existing SQL modes. This relies on the Go-MySQL-Driver allowing you to provide an expression as a value.
- Also tweaked the test script to allow you to run the tests under MySQL 8

CC @geofffranks @cphi-vmw 