### PR TITLE
PreferServerCipherSuites is deprecated

### DIFF
--- a/mutualtls/mutualtls.go
+++ b/mutualtls/mutualtls.go
@@ -18,7 +18,6 @@ func NewServerTLSConfig(certFile, keyFile, caCertFile string) (*tls.Config, erro
 		return nil, err
 	}
 	c.ClientAuth = tls.RequireAndVerifyClientCert
-	c.PreferServerCipherSuites = true
 	c.CipherSuites = []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256}
 	return c, nil
 }
@@ -43,7 +42,7 @@ func newTLSConfig(certFile, keyFile string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{keyPair},
 		MinVersion:   tls.VersionTLS12,
-		MaxVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS13,
 	}
 	return tlsConfig, nil
 }

--- a/mutualtls/mutualtls_test.go
+++ b/mutualtls/mutualtls_test.go
@@ -171,13 +171,13 @@ var _ = Describe("TLS config for internal API server", func() {
 
 			Context("when the client is configured to use an unsupported ciphersuite", func() {
 				BeforeEach(func() {
-					clientTLSConfig.CipherSuites = []uint16{tls.TLS_RSA_WITH_AES_256_GCM_SHA384}
+					clientTLSConfig.CipherSuites = []uint16{tls.TLS_AES_128_GCM_SHA256}
 				})
 
-				It("refuses the connection from the client", func() {
-					_, err := makeRequest(serverListenAddr, clientTLSConfig)
-
-					Expect(err).To(MatchError(ContainSubstring("remote error")))
+				It("negotiates the connection and will still succeed", func() {
+					resp, err := makeRequest(serverListenAddr, clientTLSConfig)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				})
 			})
 


### PR DESCRIPTION
TLS 1.3 and onward will [no longer honor PreferServerCipherSuites](https://github.com/golang/go/blob/release-branch.go1.21/src/crypto/tls/common.go#L675-L683) and it will negotiate with the server a CipherSuites that will work

Closes cloudfoundry/cf-networking-helpers#5