### PR TITLE
Wait long enough past first error for poller

### DIFF
--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Poller", func() {
 
 				Eventually(ready).Should(BeClosed())
 
-				Eventually(logger).Should(gbytes.Say("poll-cycle.*banana"))
+				Eventually(logger, 30*time.Second).Should(gbytes.Say("poll-cycle.*banana"))
 
 				Consistently(retChan).ShouldNot(Receive())
 
@@ -132,7 +132,7 @@ var _ = Describe("Poller", func() {
 				}()
 
 				Eventually(ready).Should(BeClosed())
-				Eventually(logger).Should(gbytes.Say("poll-cycle.*banana"))
+				Eventually(logger, 30*time.Second).Should(gbytes.Say("poll-cycle.*banana"))
 				Eventually(retChan).Should(Receive(MatchError(
 					"This cell must be restarted (run \"bosh restart <job>\"): fatal: banana",
 				)))


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
logger will eventually log but we need to wait long-enough 

Context: https://ci.funtime.lol/teams/wg-arp-networking/pipelines/wg-arp-networking-modules/jobs/cf-networking-helpers/builds/57


Backward Compatibility
---------------
Breaking Change? **No**
