### PR TITLE
Add ReadHeaderTimeout to lagerlevel server

### DIFF
--- a/flags/duration_flag.go
+++ b/flags/duration_flag.go
@@ -1,0 +1,28 @@
+package flags
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+type DurationFlag time.Duration
+
+func (f DurationFlag) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(f).String())
+}
+
+func (f *DurationFlag) UnmarshalJSON(b []byte) error {
+	s, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+	parsedDuration, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+
+	*f = DurationFlag(parsedDuration)
+
+	return nil
+}

--- a/flags/duration_flag_test.go
+++ b/flags/duration_flag_test.go
@@ -1,0 +1,34 @@
+package flags_test
+
+import (
+	"encoding/json"
+	"time"
+
+	"code.cloudfoundry.org/cf-networking-helpers/flags"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DurationFlag", func() {
+	type obj struct {
+		SomeInterval flags.DurationFlag `json:"some_interval"`
+	}
+
+	It("unmarshals from string to time.Duration", func() {
+		contents := []byte(`{"some_interval": "10s"}`)
+
+		var o obj
+		err := json.Unmarshal(contents, &o)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(time.Duration(o.SomeInterval)).To(Equal(10 * time.Second))
+	})
+
+	It("marshals from time.Duration to string", func() {
+		o := obj{SomeInterval: flags.DurationFlag(10 * time.Second)}
+		contents, err := json.Marshal(o)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(contents).To(MatchJSON(`{"some_interval":"10s"}`))
+	})
+})

--- a/flags/flags_suite_test.go
+++ b/flags/flags_suite_test.go
@@ -1,0 +1,13 @@
+package flags_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFlags(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flags Suite")
+}

--- a/lagerlevel/server.go
+++ b/lagerlevel/server.go
@@ -12,18 +12,20 @@ import (
 )
 
 type Server struct {
-	address string
-	port    int
-	sink    *lager.ReconfigurableSink
-	logger  lager.Logger
+	address           string
+	port              int
+	readHeaderTimeout time.Duration
+	sink              *lager.ReconfigurableSink
+	logger            lager.Logger
 }
 
-func NewServer(address string, port int, sink *lager.ReconfigurableSink, logger lager.Logger) *Server {
+func NewServer(address string, port int, readHeaderTimeout time.Duration, sink *lager.ReconfigurableSink, logger lager.Logger) *Server {
 	return &Server{
-		address: address,
-		port:    port,
-		sink:    sink,
-		logger:  logger,
+		address:           address,
+		port:              port,
+		readHeaderTimeout: readHeaderTimeout,
+		sink:              sink,
+		logger:            logger,
 	}
 }
 
@@ -33,8 +35,9 @@ func (s *Server) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 
 	address := fmt.Sprintf("%s:%d", s.address, s.port)
 	httpServer := &http.Server{
-		Addr:    address,
-		Handler: mux,
+		Addr:              address,
+		ReadHeaderTimeout: s.readHeaderTimeout,
+		Handler:           mux,
 	}
 	httpServer.SetKeepAlivesEnabled(false)
 


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
* Add option to configure ReadHeaderTimeout on lagerlevel server
* Add DurationFlag since it will be used by both service-discovery-controller and bosh-dns-adapter


Backward Compatibility
---------------
Breaking Change? **No**