### PR TITLE
Don't check for error message

### DIFF
--- a/lagerlevel/server_test.go
+++ b/lagerlevel/server_test.go
@@ -95,7 +95,6 @@ var _ = Describe("Server", func() {
 				resp := bufio.NewReader(conn)
 				_, err = resp.ReadString('\n')
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("EOF"))
 			})
 		})
 	})


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Just check for error, error message can be different on different OS


Backward Compatibility
---------------
Breaking Change? **No**

